### PR TITLE
Refactor the toolkit to use the new Python_Toolkit instead of Python.Included

### DIFF
--- a/Numpy_Engine/Convert/ToNumpy.cs
+++ b/Numpy_Engine/Convert/ToNumpy.cs
@@ -60,6 +60,13 @@ namespace BH.Engine.Numpy
 
         /***************************************************/
 
+        public static np.NDarray<short> ToNumpy(this List<short> list)
+        {
+            return np.np.array<short>(list.ToArray());
+        }
+
+        /***************************************************/
+
         public static np.NDarray<int> ToNumpy(this List<int> list)
         {
             return np.np.array<int>(list.ToArray());

--- a/Numpy_Engine/Convert/ToNumpy.cs
+++ b/Numpy_Engine/Convert/ToNumpy.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using np = Numpy;
+
+namespace BH.Engine.Numpy
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static np.NDarray<float> ToNumpy<T>(this List<T> list)
+        {
+            return np.np.array<float>(list.Cast<float>().ToArray<float>());
+        }
+
+        /***************************************************/
+
+        public static np.NDarray<float> ToNumpy(this List<float> list)
+        {
+            return np.np.array<float>(list.ToArray());
+        }
+
+        /***************************************************/
+
+        public static np.NDarray<double> ToNumpy(this List<double> list)
+        {
+            return np.np.array<double>(list.ToArray());
+        }
+
+        /***************************************************/
+
+        public static np.NDarray<decimal> ToNumpy(this List<decimal> list)
+        {
+            return np.np.array<decimal>(list.ToArray());
+        }
+
+        /***************************************************/
+
+        public static np.NDarray<int> ToNumpy(this List<int> list)
+        {
+            return np.np.array<int>(list.ToArray());
+        }
+
+        /***************************************************/
+
+        public static np.NDarray<long> ToNumpy(this List<long> list)
+        {
+            return np.np.array<long>(list.ToArray());
+        }
+
+        /***************************************************/
+    }
+}

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -92,6 +92,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>rem Install numpy python package at compile time
-$(SolutionDir)/../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "numpy"</PostBuildEvent>
+$(SolutionDir)../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "numpy"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -53,11 +53,12 @@
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Python.Included, Version=3.7.9.2, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BH.UI.Python.Included.3.7.3.9-alpha\lib\netstandard2.0\Python.Included.dll</HintPath>
-    </Reference>
     <Reference Include="Python.Runtime, Version=3.7.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\BH.UI.Python.Runtime.3.7.4-alpha\lib\netstandard2.0\Python.Runtime.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Python_Toolkit\Build\Python.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Python_Engine">
+      <HintPath>..\..\Python_Toolkit\Build\Python_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Convert\ToNumpy.cs" />
     <Compile Include="External\Constructors.cs" />
     <Compile Include="External\Methods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -90,4 +90,8 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>rem Install numpy python package at compile time
+$(SolutionDir)/../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "numpy"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -92,6 +92,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>rem Install keras python package at compile time
-$(SolutionDir)/../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "pillow" "tensorflow==2.0"</PostBuildEvent>
+$(SolutionDir)/../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "numpy"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Numpy_Engine/Numpy_Engine.csproj
+++ b/Numpy_Engine/Numpy_Engine.csproj
@@ -91,7 +91,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>rem Install numpy python package at compile time
-$(SolutionDir)../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "numpy"</PostBuildEvent>
+    <PostBuildEvent>rem Install keras python package at compile time
+$(SolutionDir)/../Python_Toolkit/Python_PostBuild/bin/Debug/Python_Postbuild.exe "pillow" "tensorflow==2.0"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Numpy_Engine/packages.config
+++ b/Numpy_Engine/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BH.UI.Python.Included" version="3.7.3.9-alpha" targetFramework="net462" />
-  <package id="BH.UI.Python.Runtime" version="3.7.4-alpha" targetFramework="net462" />
   <package id="Microsoft.CSharp" version="4.6.0" targetFramework="net462" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net462" />
 </packages>

--- a/src/Numpy/Models/NDarray.gen.cs
+++ b/src/Numpy/Models/NDarray.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/Models/PythonObject.gen.cs
+++ b/src/Numpy/Models/PythonObject.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/Numpy.csproj
+++ b/src/Numpy/Numpy.csproj
@@ -34,9 +34,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BH.UI.Python.Included" Version="3.7.3.9-alpha" />
-    <PackageReference Include="BH.UI.Python.Runtime" Version="3.7.4-alpha" />
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Python.Runtime">
+      <HintPath>..\..\..\Python_Toolkit\Build\Python.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Python_Engine">
+      <HintPath>..\..\..\Python_Toolkit\Build\Python_Engine.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/Numpy/np.array_creation.gen.cs
+++ b/src/Numpy/np.array_creation.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.array_manipulation.gen.cs
+++ b/src/Numpy/np.array_manipulation.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.bitwise.gen.cs
+++ b/src/Numpy/np.bitwise.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.datetime.gen.cs
+++ b/src/Numpy/np.datetime.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.dtype.gen.cs
+++ b/src/Numpy/np.dtype.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.dtype.routines.gen.cs
+++ b/src/Numpy/np.dtype.routines.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.fft.gen.cs
+++ b/src/Numpy/np.fft.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.financial.gen.cs
+++ b/src/Numpy/np.financial.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.indexing.gen.cs
+++ b/src/Numpy/np.indexing.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.io.gen.cs
+++ b/src/Numpy/np.io.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.linalg.gen.cs
+++ b/src/Numpy/np.linalg.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.linalg_fft.gen.cs
+++ b/src/Numpy/np.linalg_fft.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.logic.gen.cs
+++ b/src/Numpy/np.logic.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.math.gen.cs
+++ b/src/Numpy/np.math.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
+using BH.Engine.Python;
 
 namespace Numpy
 {
@@ -35,11 +35,10 @@ namespace Numpy
         
         private static PyObject InstallAndImport(bool force = false)
         {
-            Installer.SetupPython(force).Wait();
-            Installer.PipInstallModule("numpy");
+            Compute.Install(force).Wait();
+            Compute.PipInstall("numpy");
             PythonEngine.Initialize();
-            var mod = Py.Import("numpy");
-            return mod;
+            return Py.Import("numpy");
         }
         
         public static dynamic dynamic_self => self;

--- a/src/Numpy/np.padding.gen.cs
+++ b/src/Numpy/np.padding.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.random.gen.cs
+++ b/src/Numpy/np.random.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.set.gen.cs
+++ b/src/Numpy/np.set.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.sorting.gen.cs
+++ b/src/Numpy/np.sorting.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.staticstics.gen.cs
+++ b/src/Numpy/np.staticstics.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.string.gen.cs
+++ b/src/Numpy/np.string.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {

--- a/src/Numpy/np.window.gen.cs
+++ b/src/Numpy/np.window.gen.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Python.Runtime;
 using Numpy.Models;
-using Python.Included;
 
 namespace Numpy
 {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #8
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
This requires a bit of a clean up to avoid conflicts. 
1. Remove the `BHoM/Assemblies` folder
2. Compile the Python_Toolkit
3. Compile the Numpy_Toolkit
4. Use any test script from the Numpy of Keras library, e.g. https://burohappold.sharepoint.com/:f:/s/BHoM/Ei4hzzyRJqNPpqF_CHW4EmIBLrFsCtg33CEeYRZdTIvh4A?e=j7Gljx